### PR TITLE
Fix a build error

### DIFF
--- a/Sources/Accord.Imaging/Filters/HighBoost.cs
+++ b/Sources/Accord.Imaging/Filters/HighBoost.cs
@@ -73,7 +73,7 @@ namespace Accord.Imaging.Filters
             set
             {
                 boost = value;
-                kernel[size / 2, size / 2] = boost;
+                this.Kernel[size / 2, size / 2] = boost;
             }
         }
 


### PR DESCRIPTION
Modify the kernel from the public property instead of the private backing field, because that isn't in scope.